### PR TITLE
profiles regex, failback profile, wrapped PS1, and some performance enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,43 @@
 # Terminator HostWatch Plugin
 This plugin monitors the last line (PS1) of each terminator terminal, and applies a host-specific profile if the hostname is changed. 
 
-The plugin simply parses the PS1-evaluated last line and matches it against the regex `[^@]+@(\w+)` (e.g. to match `user@host`).
+## How it works
 
-If last line too short (PS1 may be two-lines text, with prompt on last line), the plugin searches for regex in the line above the prompt.
-Eg. :
+### Prompt matching
+The plugin simply parses the PS1-evaluated last line and matches it against a regex "[^@]+@(\w+)" ((e.g. user@host) to find hostname.
+
+### Profile matching
+Once an hostname is found, the plugin tries to match it against the profiles.
+Profiles might be :
+ - plain hostnames
+ - or regex
+The configuration allow to create matching rules for hostname pattern against profile.
+
+### Prompt wrapping
+PS1 might be displayed in more than one line, for instance if :
+ - very long path, wrapping over several lines
+ - terminal window too small
+ - PS1 set up for 2 lines
+
+E.g. :
+- geeky and informational PS1 :
 ```
-[user@host /a/very/long/path] /dev/pts/42
+[user@host very/long/path] /dev/pts/42
 $ 
+```  
+- unusually long PS1 due to full path display, wrapped to terminal width :
+```
+[user@host a/very/very/long/and/annoying/psychopathic/library/of/whatever/appl
+lication/path/that/wraps]$ 
 ```
 
-Profiles are either :
-  - plain hostname
-  - a regexp
+We search the first line of PS1 by searching back for last LF character in terminal history from current cursor position. The line following that LF is the PS1 first line, expected to contain 'user@host' pattern.
 
-The plugin searches for hostname exact profile matching or hostname matching profile regexp.
+To avoid unecessary treatment, a minimal prompt length might be set, mandatory if two-lines PS1 is used.
+A minimal line length is also set up, to avoid unecessary pattern search for short lines, or lines being typed and not complete.
 
-Eg. :
-```
-[profiles]
-  # matches hostname like ns123456
-  [[ns[0-9]+]]
-    ...
-  # matches hostname like ip-172-16-1-2
-  [[ip+]]
-    ...
-  # matches hostname like prd-server-1
-  [[prd-*]]
-    ...
-```
+Profile name is a plain name (the hostname), or a regexp.
+The plugin checks for exact match between hostname and profile, or profile pattern and hostname.
 
 ![Profiles](assets/terminator-hostwatch.png)
 
@@ -46,16 +55,63 @@ sudo apt-get install terminator-hostwatch
 ```
 
 **Other Linux systems:**   
-Put the `host_watch.py` in `/usr/share/terminator/terminatorlib/plugins/` or `~/.config/terminator/plugins/`. Then create a profile in Terminator to match your hostname. If you have a server that displays `user@myserver ~ $`, for instance, create a profile called `myserver`.
+Put the `host_watch.py` in `/usr/share/terminator/terminatorlib/plugins/` or `~/.config/terminator/plugins/`.
+Minimal configuration : create a profile in Terminator to match your hostname. If you have a server that displays `user@myserver ~ $`, for instance, create a profile called `myserver`.
 
 ## Configuration
-For now, the only setting you can change is the regex patterns the plugin will react on. The default pattern is `[^@]+@(\w+)` (e.g. `user@host`). To change that, add this to your .config/terminator/config file and adjust the regexes accordingly:
-
+Plugins section in `.config/terminator/config` :
 ```
 [plugins]
   [[HostWatch]]
-    patterns = "[^@]+@(\w+):([^#]+)#", "[^@]+@(\w+) .+ \$"
+    ...
 ```
+
+### Configuration keys
+The following keys are available :
+
+- prompt patterns : for prompt matching
+*key* : patterns
+*value* : a regex list. Default if not set : "[^@]+@(\w+)" (e.g. user@host)
+Don't forget to create a group in the regex for the `host` field (with `()`), otherwise no hostname can be extracted from regex.
+E.g :
+```
+patterns = "[^@]+@(\w+):([^#]+)#", "[^@]+@(\w+) .+ \$"
+```
+
+- profile patterns : searches profile against hostname pattern
+*key* : profile_patterns
+*value* : dict-like list, `pattern:profile`. Default if not set : None
+E.g :
+```
+profile_patterns = "jenkins":"inf","^itg-*":"itg","^ip-10-1-*":"itg","^ns[0-9]+":"ovh","^sd-[0-9]+":"ovh","aramis":"local"
+```
+Profiles are searched in order : first by profile patterns, then by profile name, used as patterns also (so be carefull with mixed-up config)
+  
+- minimal prompt length : triggers backward search (see wrapping above)
+Adapt this to your usual prompt length. If PS1 is a two lines prompt (see above), might be 2 chars (prompt char+space).
+*key* : prompt_minlen
+*value* : integer. Default if not set : 3
+E.g :
+```
+prompt_minlen = 8
+```
+- minimal line length : minimal length of line for pattern search when PS1 candidate line has been found.
+Adapt this to your usual PS1 length.
+*key* : line_minlen
+*value* : integer. Default if not set : 10
+  E.g :
+```
+line_minlen = 15
+```
+  
+- failback profile : profile if no matching pattern/profile found
+*key* : failback_profile
+*value* : string. Default if not set : 'default'
+E.g :
+```
+failback_profile = servers
+```
+
 ## Development
 Development resources for the Python Terminator class and the 'libvte' Python bindings can be found here:
 
@@ -78,8 +134,18 @@ $ terminator --debug-classes=HostWatch
 That should give you output like this:
 
 ```
-   HostWatch::check_host: switching to profile EMEA0014, because line 'pheckel@EMEA0014 ~ $ ' matches pattern '[^@]+@(\w+)'
-   HostWatch::check_host: switching to profile kartoffel, because line 'root@kartoffel:~# ' matches pattern '[^@]+@(\w+)'
+   HostWatch::load_profile_mappings: profile mapping : jenkins -> itg
+   HostWatch::load_profile_mappings: profile mapping : ^itg-* -> itg
+   HostWatch::load_profile_mappings: profile mapping : ^ip-10-1-* -> itg
+   HostWatch::load_profile_mappings: profile mapping : aramis -> local
+   ...
+   HostWatch::get_last_line: line below prompt min size of 6 chars : must iterate back '
+'
+   HostWatch::get_last_line: line below prompt min size of 6 chars : must iterate back '$ 
+'
+   HostWatch::check_host: match search pattern : ^\[[a-zA-Z0-9-]+@([a-zA-Z0-9-]+) * ([devel@aramis ~/.config/terminator/plugins] 14:47:50 0 /dev/pts/11) ->aramis
+   HostWatch::check_host: matching profile 'local' found : line '[devel@aramis ~/.config/terminator/plugins] 14:47:50 0 /dev/pts/11' matches prompt pattern '^\[[a-zA-Z0-9-]+@([a-zA-Z0-9-]+) *' and profile pattern 'aramis'
+   HostWatch::check_host: setting profile local
    ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ The plugin simply parses the PS1-evaluated last line and matches it against a re
 
 ### Profile matching
 Once an hostname is found, the plugin tries to match it against the profiles.
+
 Profiles might be :
  - plain hostnames
  - or regex
+
 The configuration allow to create matching rules for hostname pattern against profile.
 
 ### Prompt wrapping
@@ -56,6 +58,7 @@ sudo apt-get install terminator-hostwatch
 
 **Other Linux systems:**   
 Put the `host_watch.py` in `/usr/share/terminator/terminatorlib/plugins/` or `~/.config/terminator/plugins/`.
+
 Minimal configuration : create a profile in Terminator to match your hostname. If you have a server that displays `user@myserver ~ $`, for instance, create a profile called `myserver`.
 
 ## Configuration
@@ -70,17 +73,24 @@ Plugins section in `.config/terminator/config` :
 The following keys are available :
 
 - prompt patterns : for prompt matching
+
 *key* : patterns
+
 *value* : a regex list. Default if not set : "[^@]+@(\w+)" (e.g. user@host)
+
 Don't forget to create a group in the regex for the `host` field (with `()`), otherwise no hostname can be extracted from regex.
+
 E.g :
 ```
 patterns = "[^@]+@(\w+):([^#]+)#", "[^@]+@(\w+) .+ \$"
 ```
 
 - profile patterns : searches profile against hostname pattern
+
 *key* : profile_patterns
+
 *value* : dict-like list, `pattern:profile`. Default if not set : None
+
 E.g :
 ```
 profile_patterns = "jenkins":"inf","^itg-*":"itg","^ip-10-1-*":"itg","^ns[0-9]+":"ovh","^sd-[0-9]+":"ovh","aramis":"local"
@@ -88,25 +98,36 @@ profile_patterns = "jenkins":"inf","^itg-*":"itg","^ip-10-1-*":"itg","^ns[0-9]+"
 Profiles are searched in order : first by profile patterns, then by profile name, used as patterns also (so be carefull with mixed-up config)
   
 - minimal prompt length : triggers backward search (see wrapping above)
+
 Adapt this to your usual prompt length. If PS1 is a two lines prompt (see above), might be 2 chars (prompt char+space).
+
 *key* : prompt_minlen
+
 *value* : integer. Default if not set : 3
+
 E.g :
 ```
 prompt_minlen = 8
 ```
 - minimal line length : minimal length of line for pattern search when PS1 candidate line has been found.
+
 Adapt this to your usual PS1 length.
+
 *key* : line_minlen
+
 *value* : integer. Default if not set : 10
+
   E.g :
 ```
 line_minlen = 15
 ```
   
 - failback profile : profile if no matching pattern/profile found
+
 *key* : failback_profile
+
 *value* : string. Default if not set : 'default'
+
 E.g :
 ```
 failback_profile = servers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,34 @@
 # Terminator HostWatch Plugin
 This plugin monitors the last line (PS1) of each terminator terminal, and applies a host-specific profile if the hostname is changed. 
 
-As of now, the plugin simply parses the PS1-evaluated last line and matches it against the regex `[^@]+@(\w+)` (e.g. to match `user@host`).
+The plugin simply parses the PS1-evaluated last line and matches it against the regex `[^@]+@(\w+)` (e.g. to match `user@host`).
+
+If last line too short (PS1 may be two-lines text, with prompt on last line), the plugin searches for regex in the line above the prompt.
+Eg. :
+```
+[user@host /a/very/long/path] /dev/pts/42
+$ 
+```
+
+Profiles are either :
+  - plain hostname
+  - a regexp
+
+The plugin searches for hostname exact profile matching or hostname matching profile regexp.
+
+Eg. :
+```
+[profiles]
+  # matches hostname like ns123456
+  [[ns[0-9]+]]
+    ...
+  # matches hostname like ip-172-16-1-2
+  [[ip+]]
+    ...
+  # matches hostname like prd-server-1
+  [[prd-*]]
+    ...
+```
 
 ![Profiles](assets/terminator-hostwatch.png)
 


### PR DESCRIPTION
hello all,

This plugin is really usefull to me. Since I work on several platforms, with a lot of opened terminals all day long, it changed my sysadmin life!

Added the following functionalities :
- failback profile : if prompt found, but no profile found, we don't keep current profile, but switch to failback profile. The need was, from our developers team : "switch profile if I'm not on my own computer". Seems good to switch profile if we change our host whatever. Avoids making mistakes.
- profile matching based on plain hostname or regex : if you want to apply the same profile to several servers (e.g same color for all the staging or production servers)

Some performance enhancements :
- using compiled regex, loaded at init
- config only loaded and parsed at init
- trigger line search for matching regex only above a defined length, else do nothing

Prompt wrapping :
- wen prompt is wrapped, last line is only part of the prompt, so we search for first line of prompt, rather than last line
- ... or prompt can be displayed in two lines : since I display full path on prompt, my PS1 is of the form :
"[\u@\h \w] \t \j $(tty)\n$ "
My algorithm is very ugly, so feel free to improve it and make it more pythonic...

Potential bug :
- maybe we should concatenate the whole prompt line if wrapped, considering hostname is splitted?